### PR TITLE
ACCUMULO-4065 Tweak generics in RpcWrapper code

### DIFF
--- a/server/base/src/test/java/org/apache/accumulo/server/util/RpcWrapperTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/util/RpcWrapperTest.java
@@ -37,11 +37,14 @@ import com.google.common.collect.Sets;
 public class RpcWrapperTest {
 
   private static final String RTE_MESSAGE = "RpcWrapperTest's RuntimeException Message";
+
   /**
    * Given a method name and whether or not the method is oneway, construct a ProcessFunction.
    *
-   * @param methodName The service method name.
-   * @param isOneway Is the method oneway.
+   * @param methodName
+   *          The service method name.
+   * @param isOneway
+   *          Is the method oneway.
    * @return A ProcessFunction.
    */
   private fake_proc<FakeService> createProcessFunction(String methodName, boolean isOneway) {
@@ -50,8 +53,7 @@ public class RpcWrapperTest {
 
   @Test
   public void testSomeOnewayMethods() {
-    @SuppressWarnings("rawtypes")
-    Map<String,ProcessFunction<FakeService,? extends TBase>> procs = new HashMap<String,ProcessFunction<FakeService,? extends TBase>>();
+    Map<String,ProcessFunction<FakeService,?>> procs = new HashMap<String,ProcessFunction<FakeService,?>>();
     procs.put("foo", createProcessFunction("foo", true));
     procs.put("foobar", createProcessFunction("foobar", false));
     procs.put("bar", createProcessFunction("bar", true));
@@ -63,8 +65,7 @@ public class RpcWrapperTest {
 
   @Test
   public void testNoOnewayMethods() {
-    @SuppressWarnings("rawtypes")
-    Map<String,ProcessFunction<FakeService,? extends TBase>> procs = new HashMap<String,ProcessFunction<FakeService,? extends TBase>>();
+    Map<String,ProcessFunction<FakeService,?>> procs = new HashMap<String,ProcessFunction<FakeService,?>>();
     procs.put("foo", createProcessFunction("foo", false));
     procs.put("foobar", createProcessFunction("foobar", false));
     procs.put("bar", createProcessFunction("bar", false));
@@ -76,8 +77,7 @@ public class RpcWrapperTest {
 
   @Test
   public void testAllOnewayMethods() {
-    @SuppressWarnings("rawtypes")
-    Map<String,ProcessFunction<FakeService,? extends TBase>> procs = new HashMap<String,ProcessFunction<FakeService,? extends TBase>>();
+    Map<String,ProcessFunction<FakeService,?>> procs = new HashMap<String,ProcessFunction<FakeService,?>>();
     procs.put("foo", createProcessFunction("foo", true));
     procs.put("foobar", createProcessFunction("foobar", true));
     procs.put("bar", createProcessFunction("bar", true));
@@ -154,8 +154,11 @@ public class RpcWrapperTest {
    */
   interface FakeService {
     void foo();
+
     String foobar();
+
     int bar();
+
     long barfoo();
   }
 
@@ -187,7 +190,7 @@ public class RpcWrapperTest {
   /**
    * A fake ProcessFunction implementation for testing that allows injection of method name and oneway.
    */
-  private static class fake_proc<I extends FakeService> extends org.apache.thrift.ProcessFunction<I, foo_args> {
+  private static class fake_proc<I extends FakeService> extends org.apache.thrift.ProcessFunction<I,foo_args> {
     final private boolean isOneway;
 
     public fake_proc(String methodName, boolean isOneway) {
@@ -215,7 +218,7 @@ public class RpcWrapperTest {
   /**
    * Fake arguments for our fake service.
    */
-  private static class foo_args implements org.apache.thrift.TBase<foo_args, fake_fields> {
+  private static class foo_args implements org.apache.thrift.TBase<foo_args,fake_fields> {
 
     private static final long serialVersionUID = 1L;
 
@@ -225,12 +228,10 @@ public class RpcWrapperTest {
     }
 
     @Override
-    public void read(TProtocol iprot) throws TException {
-    }
+    public void read(TProtocol iprot) throws TException {}
 
     @Override
-    public void write(TProtocol oprot) throws TException {
-    }
+    public void write(TProtocol oprot) throws TException {}
 
     @Override
     public fake_fields fieldForId(int fieldId) {

--- a/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
+++ b/server/gc/src/main/java/org/apache/accumulo/gc/SimpleGarbageCollector.java
@@ -295,8 +295,8 @@ public class SimpleGarbageCollector implements Iface {
 
     @Override
     public Iterator<String> getBlipIterator() throws TableNotFoundException, AccumuloException, AccumuloSecurityException {
-      IsolatedScanner scanner = new IsolatedScanner(instance.getConnector(credentials.getPrincipal(), credentials.getToken()).createScanner(tableName,
-          Authorizations.EMPTY));
+      IsolatedScanner scanner = new IsolatedScanner(
+          instance.getConnector(credentials.getPrincipal(), credentials.getToken()).createScanner(tableName, Authorizations.EMPTY));
 
       scanner.setRange(MetadataSchema.BlipSection.getRange());
 
@@ -310,8 +310,8 @@ public class SimpleGarbageCollector implements Iface {
 
     @Override
     public Iterator<Entry<Key,Value>> getReferenceIterator() throws TableNotFoundException, AccumuloException, AccumuloSecurityException {
-      IsolatedScanner scanner = new IsolatedScanner(instance.getConnector(credentials.getPrincipal(), credentials.getToken()).createScanner(tableName,
-          Authorizations.EMPTY));
+      IsolatedScanner scanner = new IsolatedScanner(
+          instance.getConnector(credentials.getPrincipal(), credentials.getToken()).createScanner(tableName, Authorizations.EMPTY));
       scanner.fetchColumnFamily(DataFileColumnFamily.NAME);
       scanner.fetchColumnFamily(ScanFileColumnFamily.NAME);
       TabletsSection.ServerColumnFamily.DIRECTORY_COLUMN.fetch(scanner);
@@ -702,7 +702,7 @@ public class SimpleGarbageCollector implements Iface {
   }
 
   private HostAndPort startStatsService() throws UnknownHostException {
-    Processor<Iface> processor = new Processor<Iface>(RpcWrapper.service(this, new Processor<Iface>(this).getProcessMapView()));
+    Processor<Iface> processor = new Processor<Iface>(RpcWrapper.service(this, new Processor<Iface>(this)));
     int port = config.getPort(Property.GC_PORT);
     long maxMessageSize = config.getMemoryInBytes(Property.GENERAL_MAX_MESSAGE_SIZE);
     HostAndPort result = HostAndPort.fromParts(opts.getAddress(), port);

--- a/server/master/src/main/java/org/apache/accumulo/master/Master.java
+++ b/server/master/src/main/java/org/apache/accumulo/master/Master.java
@@ -288,8 +288,8 @@ public class Master implements LiveTServerSet.Listener, TableObserver, CurrentSt
       Accumulo.abortIfFateTransactions();
 
       if (serverConfig.getConfiguration().get(Property.INSTANCE_VOLUMES).trim().length() > 0) {
-        throw new IllegalStateException("Do not set property " + Property.INSTANCE_VOLUMES.getKey()
-            + " until after upgrade. Kill all Accumulo processes, unset property, and try again.");
+        throw new IllegalStateException(
+            "Do not set property " + Property.INSTANCE_VOLUMES.getKey() + " until after upgrade. Kill all Accumulo processes, unset property, and try again.");
       }
 
       try {
@@ -841,7 +841,7 @@ public class Master implements LiveTServerSet.Listener, TableObserver, CurrentSt
                   break;
               }
           }
-        }catch(Throwable t) {
+        } catch (Throwable t) {
           log.error("Error occurred reading / switching master goal state. Will continue with attempt to update status", t);
         }
 
@@ -1012,8 +1012,8 @@ public class Master implements LiveTServerSet.Listener, TableObserver, CurrentSt
     waitForMetadataUpgrade.await();
 
     try {
-      final AgeOffStore<Master> store = new AgeOffStore<Master>(new org.apache.accumulo.fate.ZooStore<Master>(ZooUtil.getRoot(instance) + Constants.ZFATE,
-          ZooReaderWriter.getInstance()), 1000 * 60 * 60 * 8);
+      final AgeOffStore<Master> store = new AgeOffStore<Master>(
+          new org.apache.accumulo.fate.ZooStore<Master>(ZooUtil.getRoot(instance) + Constants.ZFATE, ZooReaderWriter.getInstance()), 1000 * 60 * 60 * 8);
 
       int threads = this.getConfiguration().getConfiguration().getCount(Property.MASTER_FATE_THREADPOOL_SIZE);
 
@@ -1032,8 +1032,8 @@ public class Master implements LiveTServerSet.Listener, TableObserver, CurrentSt
       throw new IOException(e);
     }
 
-    Processor<Iface> processor = new Processor<Iface>(RpcWrapper.service(new MasterClientServiceHandler(this),
-        new Processor<Iface>(new MasterClientServiceHandler(this)).getProcessMapView()));
+    Processor<Iface> processor = new Processor<Iface>(
+        RpcWrapper.service(new MasterClientServiceHandler(this), new Processor<Iface>(new MasterClientServiceHandler(this))));
     ServerAddress sa = TServerUtils.startServer(getSystemConfiguration(), hostname, Property.MASTER_CLIENTPORT, processor, "Master",
         "Master Client Service Handler", null, Property.MASTER_MINTHREADS, Property.MASTER_THREADCHECK, Property.GENERAL_MAX_MESSAGE_SIZE);
     clientService = sa.server;

--- a/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
+++ b/server/tserver/src/main/java/org/apache/accumulo/tserver/TabletServer.java
@@ -652,8 +652,8 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
           }
 
           activeScans.add(new ActiveScan(mss.client, mss.user, mss.threadPoolExtent.getTableId().toString(), ct - mss.startTime, ct - mss.lastAccessTime,
-              ScanType.BATCH, state, mss.threadPoolExtent.toThrift(), Translator.translate(mss.columnSet, Translators.CT), mss.ssiList, mss.ssio, mss.auths
-                  .getAuthorizationsBB()));
+              ScanType.BATCH, state, mss.threadPoolExtent.toThrift(), Translator.translate(mss.columnSet, Translators.CT), mss.ssiList, mss.ssio,
+              mss.auths.getAuthorizationsBB()));
         }
       }
 
@@ -1067,8 +1067,8 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
 
           runState.set(ScanRunState.RUNNING);
 
-          Thread.currentThread().setName(
-              "User: " + scanSession.user + " Start: " + scanSession.startTime + " Client: " + scanSession.client + " Tablet: " + scanSession.extent);
+          Thread.currentThread()
+              .setName("User: " + scanSession.user + " Start: " + scanSession.startTime + " Client: " + scanSession.client + " Tablet: " + scanSession.extent);
 
           Tablet tablet = onlineTablets.get(scanSession.extent);
 
@@ -1157,8 +1157,8 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
               failures.put(entry.getKey(), entry.getValue());
               continue;
             }
-            Thread.currentThread().setName(
-                "Client: " + session.client + " User: " + session.user + " Start: " + session.startTime + " Tablet: " + entry.getKey().toString());
+            Thread.currentThread()
+                .setName("Client: " + session.client + " User: " + session.user + " Start: " + session.startTime + " Tablet: " + entry.getKey().toString());
 
             LookupResult lookupResult;
             try {
@@ -1297,8 +1297,8 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
     }
 
     @Override
-    public ScanResult continueScan(TInfo tinfo, long scanID) throws NoSuchScanIDException, NotServingTabletException,
-        org.apache.accumulo.core.tabletserver.thrift.TooManyFilesException {
+    public ScanResult continueScan(TInfo tinfo, long scanID)
+        throws NoSuchScanIDException, NotServingTabletException, org.apache.accumulo.core.tabletserver.thrift.TooManyFilesException {
       ScanSession scanSession = (ScanSession) sessionManager.reserveSession(scanID);
       if (scanSession == null) {
         throw new NoSuchScanIDException();
@@ -1311,8 +1311,8 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
       }
     }
 
-    private ScanResult continueScan(TInfo tinfo, long scanID, ScanSession scanSession) throws NoSuchScanIDException, NotServingTabletException,
-        org.apache.accumulo.core.tabletserver.thrift.TooManyFilesException {
+    private ScanResult continueScan(TInfo tinfo, long scanID, ScanSession scanSession)
+        throws NoSuchScanIDException, NotServingTabletException, org.apache.accumulo.core.tabletserver.thrift.TooManyFilesException {
 
       if (scanSession.nextBatchTask == null) {
         scanSession.nextBatchTask = new NextBatchTask(scanID, scanSession.interruptFlag);
@@ -1374,8 +1374,8 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
       if (ss != null) {
         long t2 = System.currentTimeMillis();
 
-        log.debug(String.format("ScanSess tid %s %s %,d entries in %.2f secs, nbTimes = [%s] ", TServerUtils.clientAddress.get(), ss.extent.getTableId()
-            .toString(), ss.entriesReturned, (t2 - ss.startTime) / 1000.0, ss.nbTimes.toString()));
+        log.debug(String.format("ScanSess tid %s %s %,d entries in %.2f secs, nbTimes = [%s] ", TServerUtils.clientAddress.get(),
+            ss.extent.getTableId().toString(), ss.entriesReturned, (t2 - ss.startTime) / 1000.0, ss.nbTimes.toString()));
         if (scanMetrics.isEnabled()) {
           scanMetrics.add(TabletServerScanMetrics.scan, t2 - ss.startTime);
           scanMetrics.add(TabletServerScanMetrics.resultSize, ss.entriesReturned);
@@ -1407,8 +1407,8 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
         log.error(tse, tse);
         throw tse;
       }
-      Map<KeyExtent,List<Range>> batch = Translator.translate(tbatch, new TKeyExtentTranslator(), new Translator.ListTranslator<TRange,Range>(
-          new TRangeTranslator()));
+      Map<KeyExtent,List<Range>> batch = Translator.translate(tbatch, new TKeyExtentTranslator(),
+          new Translator.ListTranslator<TRange,Range>(new TRangeTranslator()));
 
       // This is used to determine which thread pool to use
       KeyExtent threadPoolExtent = batch.keySet().iterator().next();
@@ -1802,13 +1802,13 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
         log.debug(String.format("Authentication Failures: %d, first %s", us.authFailures.size(), first.toString()));
       }
 
-      return new UpdateErrors(Translator.translate(us.failures, Translators.KET), Translator.translate(violations, Translators.CVST), Translator.translate(
-          us.authFailures, Translators.KET));
+      return new UpdateErrors(Translator.translate(us.failures, Translators.KET), Translator.translate(violations, Translators.CVST),
+          Translator.translate(us.authFailures, Translators.KET));
     }
 
     @Override
-    public void update(TInfo tinfo, TCredentials credentials, TKeyExtent tkeyExtent, TMutation tmutation) throws NotServingTabletException,
-        ConstraintViolationException, ThriftSecurityException {
+    public void update(TInfo tinfo, TCredentials credentials, TKeyExtent tkeyExtent, TMutation tmutation)
+        throws NotServingTabletException, ConstraintViolationException, ThriftSecurityException {
 
       String tableId = new String(tkeyExtent.getTable(), UTF_8);
       if (!security.canWrite(credentials, tableId, Tables.getNamespaceId(instance, tableId)))
@@ -2165,8 +2165,8 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
     }
 
     @Override
-    public void splitTablet(TInfo tinfo, TCredentials credentials, TKeyExtent tkeyExtent, ByteBuffer splitPoint) throws NotServingTabletException,
-        ThriftSecurityException {
+    public void splitTablet(TInfo tinfo, TCredentials credentials, TKeyExtent tkeyExtent, ByteBuffer splitPoint)
+        throws NotServingTabletException, ThriftSecurityException {
 
       String tableId = new String(ByteBufferUtil.toBytes(tkeyExtent.table));
       String namespaceId;
@@ -2323,8 +2323,8 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
               all.remove(extent);
 
               if (all.size() > 0) {
-                log.error("Tablet " + extent + " overlaps previously assigned " + unopenedOverlapping + " " + openingOverlapping + " " + onlineOverlapping
-                    + " " + all);
+                log.error("Tablet " + extent + " overlaps previously assigned " + unopenedOverlapping + " " + openingOverlapping + " " + onlineOverlapping + " "
+                    + all);
               }
               return;
             }
@@ -2935,7 +2935,8 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
       Text locationToOpen = null;
       SortedMap<Key,Value> tabletsKeyValues = new TreeMap<Key,Value>();
       try {
-        Pair<Text,KeyExtent> pair = verifyTabletInformation(extent, TabletServer.this.getTabletSession(), tabletsKeyValues, getClientAddressString(), getLock());
+        Pair<Text,KeyExtent> pair = verifyTabletInformation(extent, TabletServer.this.getTabletSession(), tabletsKeyValues, getClientAddressString(),
+            getLock());
         if (pair != null) {
           locationToOpen = pair.getFirst();
           if (pair.getSecond() != null) {
@@ -3160,7 +3161,7 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
   private HostAndPort startTabletClientService() throws UnknownHostException {
     // start listening for client connection last
     ThriftClientHandler handler = new ThriftClientHandler();
-    Iface tch = RpcWrapper.service(handler, new Processor<Iface>(handler).getProcessMapView());
+    Iface tch = RpcWrapper.service(handler, new Processor<Iface>(handler));
     Processor<Iface> processor = new Processor<Iface>(tch);
     HostAndPort address = startServer(getSystemConfiguration(), clientAddress.getHostText(), Property.TSERV_CLIENTPORT, processor, "Thrift Client Server");
     log.info("address = " + address);
@@ -3287,8 +3288,8 @@ public class TabletServer extends AbstractMetricsImpl implements org.apache.accu
           // if while loop does not execute at all and mm != null,
           // then
           // finally block should place mm back on queue
-          while (!serverStopRequested && mm != null && client != null && client.getOutputProtocol() != null
-              && client.getOutputProtocol().getTransport() != null && client.getOutputProtocol().getTransport().isOpen()) {
+          while (!serverStopRequested && mm != null && client != null && client.getOutputProtocol() != null && client.getOutputProtocol().getTransport() != null
+              && client.getOutputProtocol().getTransport().isOpen()) {
             try {
               mm.send(SystemCredentials.get().toThrift(instance), getClientAddressString(), iface);
               mm = null;


### PR DESCRIPTION
- depend more on compile time checks with generic checking
- use better naming of generic params (I for Iface, P for Processor) to clarify
  relationship between types
- remove unneeded casts and warnings suppressions
